### PR TITLE
Adds coverage tox targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ build/
 dist/
 *.pyc
 .tox
+.coverage
+cover

--- a/tox.ini
+++ b/tox.ini
@@ -15,3 +15,22 @@ deps =
     nose
 commands =
     nosetests
+
+[testenv:coverage]
+deps =
+     nose
+     coverage
+
+commands =
+    nosetests --with-coverage --cover-package slackcollector
+
+[testenv:coverageosx]
+whitelist_externals =
+    open
+deps =
+     nose
+     coverage
+
+commands =
+    nosetests --with-coverage --cover-package slackcollector --cover-html
+    open cover/index.html


### PR DESCRIPTION
2 targets:
- `coverage`: executes `coverage` and prints a report in the terminal
- `coverageosx`: executes `coverage` and prints the results in an
  explorable HTML file. (Only works on OSX)

You can execute them locally with `tox -e coverage` and `tox -e coverageosx`. The HTML version is clickable and shows you which statements are not covered by our tests.

_Golden rule of coverage_: No need to shoot for 100% coverage, we just need to identify which areas are lacking the most.
