### PR TITLE
Introduces command line arguments with argparse

### DIFF
--- a/slackcollector/collector.py
+++ b/slackcollector/collector.py
@@ -24,6 +24,7 @@
 
 """The main Collector module."""
 
+import argparse
 import yaml
 import os
 import io
@@ -72,9 +73,7 @@ class Collector:
 
     def load_config(self, config_file_path):
         """Parse the configuration file."""
-        config_file = os.path.join(os.path.dirname(__file__),
-                                   '../config/' + config_file_path)
-        config = yaml.safe_load(open(config_file))
+        config = yaml.safe_load(open(config_file_path))
         self.data_dir = config['storage']['data_dir']
         self.data_file_prefix = config['storage']['data_file_prefix']
         slack.api_token = config['secure']['slack_group_token']
@@ -123,7 +122,13 @@ class Collector:
 
 
 if __name__ == "__main__":
-    collector = Collector('config.yml')
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-c', '--config', type=str,
+                        default='config.yml',
+                        help="Path to the configuration file ")
+    args = parser.parse_args()
+    collector = Collector(args.config)
     data = collector.collect_data()
     data = collector.anonymize_data(data)
     collector.write_data(data)

--- a/slackcollector/tests/test_collector.py
+++ b/slackcollector/tests/test_collector.py
@@ -30,7 +30,7 @@ from slackcollector.collector import Collector
 class TestCollector(unittest.TestCase):
 
     def setUp(self):
-        self.config_file = 'config.example.yml'
+        self.config_file = 'config/config.example.yml'
         self.collector_inst = Collector(self.config_file)
 
     def test_load_config_file_success(self):


### PR DESCRIPTION
First argument is to locate the config file.

**Beware**: This patch might break previous installs, depending on how
the script was launched. However this change is necessary since we need
to get rid of `../config/` (a poor idea that ruins our flexibility).

The scripts now expects an explicit path to the config file, defaulting
to `config.yml` in the current directory.

Make sure to check `python collector.py -h` for the newly available help
message.
