### PR TITLE
Adds an extra static check for import order

### DIFF
--- a/slackcollector/collector.py
+++ b/slackcollector/collector.py
@@ -24,15 +24,16 @@
 
 """The main Collector module."""
 
-import yaml
-import os
+import datetime
 import io
 import json
-import datetime
+import logging
+import os
 import sys
+
 import slack
 import slack.users
-import logging
+import yaml
 
 
 class Collector:

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,14 @@ envlist = linters,py27,py35
 deps =
     flake8
     mastool
+    flake8-import-order
     pep257
 commands =
     flake8
-     pep257 slackcollector
+    pep257 slackcollector
+
+[flake8]
+import-order-style = pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
Enables [one extra module](https://pypi.python.org/pypi/flake8-import-order) for static checks.

This is a minor nitpick of mine. Feel free to ignore this if you think it's a PITA.
