### PR TITLE
Improves our unit test coverage

### DIFF
--- a/slackcollector/collector.py
+++ b/slackcollector/collector.py
@@ -44,21 +44,8 @@ class Collector:
 
     def __init__(self, config_file=None):
         """Load the config file and handle potential errors."""
+        self.load_config(config_file)
         self.configure_logging()
-        try:
-            self.load_config(config_file)
-        except IOError:
-            self.logger.error(
-                'Configuration file does not exist. Make sure'
-                ' the file "{}" exists and is '
-                'configured correctly.'.format(config_file))
-            sys.exit(1)
-        except yaml.scanner.ScannerError:
-            self.logger.error(
-                'Corrupted configuration file - could not be '
-                'parsed make sure "{}" is configured '
-                'correctly.'.format(config_file))
-            sys.exit(2)
 
     def configure_logging(self, level=logging.DEBUG):
         """Instanciate and configure a logger."""
@@ -74,10 +61,23 @@ class Collector:
         """Parse the configuration file."""
         config_file = os.path.join(os.path.dirname(__file__),
                                    '../config/' + config_file_path)
-        config = yaml.safe_load(open(config_file))
-        self.data_dir = config['storage']['data_dir']
-        self.data_file_prefix = config['storage']['data_file_prefix']
-        slack.api_token = config['secure']['slack_group_token']
+        try:
+            config = yaml.safe_load(open(config_file))
+            self.data_dir = config['storage']['data_dir']
+            self.data_file_prefix = config['storage']['data_file_prefix']
+            slack.api_token = config['secure']['slack_group_token']
+        except IOError:
+            self.logger.error(
+                'Configuration file does not exist. Make sure'
+                ' the file "{}" exists and is '
+                'configured correctly.'.format(config_file))
+            sys.exit(1)
+        except yaml.scanner.ScannerError:
+            self.logger.error(
+                'Corrupted configuration file - could not be '
+                'parsed make sure "{}" is configured '
+                'correctly.'.format(config_file))
+            sys.exit(2)
 
     def collect_data(self):
         """Query the Slack API and retrieve user data."""

--- a/slackcollector/tests/_test_data/invalid_conf.yml
+++ b/slackcollector/tests/_test_data/invalid_conf.yml
@@ -1,0 +1,1 @@
+['Not a YAML file

--- a/slackcollector/tests/test_collector.py
+++ b/slackcollector/tests/test_collector.py
@@ -24,6 +24,9 @@ import json
 import os
 import unittest
 
+import mock
+import slack.users
+
 from slackcollector.collector import Collector
 
 
@@ -32,6 +35,7 @@ class TestCollector(unittest.TestCase):
     def setUp(self):
         self.config_file = 'config.example.yml'
         self.collector_inst = Collector(self.config_file)
+        self.collector_inst.logger = mock.MagicMock()
 
     def test_load_config_file_success(self):
         self.collector_inst.load_config(self.config_file)
@@ -42,8 +46,8 @@ class TestCollector(unittest.TestCase):
         """
         Test a non existent configuration file
         """
-        self.assertRaises(IOError, self.collector_inst.load_config,
-                          '/boguspath')
+        self.assertRaises(SystemExit,
+                          self.collector_inst.load_config, '/boguspath')
 
     def test_anonymize_data_success(self):
         """
@@ -52,7 +56,6 @@ class TestCollector(unittest.TestCase):
         """
         test_json_file = os.path.join(os.path.dirname(__file__),
                                       '_test_data/sensitive_json.json')
-
         with open(test_json_file) as data_file:
             json_data = json.load(data_file)
         clean_json_data = self.collector_inst.anonymize_data(json_data)
@@ -62,6 +65,23 @@ class TestCollector(unittest.TestCase):
             # empty the we have cleared these keys and their values
             self.assertFalse(sensitive_keys_set.intersection(set(item.keys())))
 
+    def test_collect_data_success(self):
+        """
+        Test that the correct API call is made in the `collect_data` method
+        """
+        self.collector_inst.logger = mock.MagicMock()
+        slack.users.list = mock.MagicMock(return_value='{}')
+        data = self.collector_inst.collect_data()
+        self.assertEqual(data, "{}")
+
+    def test_load_invalid_config_failure(self):
+        """
+        Test loading an invalid configuration file
+        """
+        # TODO(joehakimrahme): Fix this monstrosity once PR #10 is merged.
+        invalid_config = '../slackcollector/tests/_test_data/invalid_conf.yml'
+        self.assertRaises(SystemExit,
+                          self.collector_inst.load_config, invalid_config)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -13,13 +13,15 @@ commands =
 [testenv]
 deps =
     nose
+    mock
 commands =
-    nosetests
+    nosetests {posargs}
 
 [testenv:coverage]
 deps =
-     nose
      coverage
+     mock
+     nose
 
 commands =
     nosetests --with-coverage --cover-package slackcollector
@@ -28,8 +30,9 @@ commands =
 whitelist_externals =
     open
 deps =
-     nose
      coverage
+     mock
+     nose
 
 commands =
     nosetests --with-coverage --cover-package slackcollector --cover-html


### PR DESCRIPTION
Some more unit tests to increase our overall coverage of the script.

Introduces the `mock` module as a test dependency.
Note that Python3 supports `unittest.mock` in the standard library.

Some refactoring need to be done in `test_load_invalid_config_failure` once the PR #10 is merged (As far as I know Github doesn't support dependent PRs so I had to find a temporary solution).
